### PR TITLE
Add in non-root user, docker secret support, and more

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ ARG POSTGRES_VERSION=12.1
 FROM postgres:${POSTGRES_VERSION}
 LABEL org.opencontainers.image.authors="rowe.andrew.d@gmail.com"
 
+RUN \
+apt-get update && \
+apt-get install -y cron  && \
+apt-get clean && \
+rm -rf /var/lib/apt/lists/*
+
 EXPOSE 5432
-ENV PGUSER=postgres
 ENV PGDATA="/data"
+ENV PGDUMP="/dump"
+ENV PGUSER=postgres
 
 COPY --chown=${PGUSER}:${PGUSER} \
    [ "dump.sh", \
@@ -13,21 +20,17 @@ COPY --chown=${PGUSER}:${PGUSER} \
 
 USER root
 
-VOLUME [ "/dump", "/data" ]
-
 RUN \
-apt-get update && \
-apt-get install -y cron  && \
-apt-get clean && \
-rm -rf /var/lib/apt/lists/* && \
 chmod 755 dump.sh && \
 chmod 755 entrypoint.sh && \
 chmod gu+rw /var/run && \
 chmod gu+s /usr/sbin/cron && \
-mkdir /dump && \
-chown ${PGUSER}:${PGUSER} /dump && \
-mkdir /data && \
-chown ${PGUSER}:${PGUSER} /data
+mkdir ${PGDUMP} && \
+chown ${PGUSER}:${PGUSER} ${PGDUMP} && \
+mkdir ${PGDATA} && \
+chown ${PGUSER}:${PGUSER} ${PGDATA}
+
+VOLUME [ ${PGDUMP}, ${PGDATA} ]
 
 USER ${PGUSER}
 

--- a/README.md
+++ b/README.md
@@ -12,34 +12,37 @@ runs every day at 1:00 am).
 
 ## Environment Variables:
 
-| Variable        | Required? | Default   | Description                                                         |
-|-----------------|:----------|:----------|:--------------------------------------------------------------------|
-| `PGUSER`        | Optional  | postgres  | The user for accessing the database                                 |
-| `PGPASSWORD`    | Optional  | `None`    | The password for accessing the database                             |
-| `POSTGRES_DB`   | Optional  | postgres  | The name of the database                                            |
-| `PGHOST`        | Optional  | localhost | The hostname of the database                                        |
-| `PGPORT`        | Optional  | `5432`    | The port for the database                                           |
-| `CRON_SCHEDULE` | Required  | 0 1 * * * | The cron schedule at which to run the pg_dump                       |
-| `RETAIN_COUNT`  | Optional  | `None`    | Optionally, a number to retain, delete older files                  |
-| `PREFIX`        | Optional  | dump      | Optionally, prefix for dump files                                   |
-| `PGDUMP`        | Optional  | /dump     | Optionally, define a different location to dump your backups.       |
-| `LOGFIFO`       | Optional  | `${PGDUMP}/cron.fifo` | Location to write cron logs to.                         |
-| `POSTGRES_PASSWORD_FILE`    | Recomended  | `/run/secrets/db_password` | Location of the password file          |
-| `PG_LOG`        | Optional  | `None`    | Optionally, set any value to view this env inside of the container  |
+| Variable                 | Alias        | Required?  | Default               | Description                                                                   |
+|--------------------------|:-------------|:-----------|:----------------------|:------------------------------------------------------------------------------|
+| `PGUSER`                 | `None`       | Optional   | postgres              | The user for accessing the database                                           |
+| `POSTGRES_PASSWORD`      | `PGPASSWORD` | Optional   | `None`                | The password for accessing the database                                       |
+| `POSTGRES_DB`            | `PGDB`       | Optional   | postgres              | The name of the database                                                      |
+| `PGHOST`                 | `None`       | Optional   | db/localhost | The hostname of the database. `db` is the default if RUN_DOUBLE, `localhost` otherwise |
+| `PGPORT`                 | `None`       | Optional   | `5432`                | The port for the database                                                     |
+| `CRON_SCHEDULE`          | `None`       | Required   | 0 1 * * *             | The cron schedule at which to run the pg_dump                                 |
+| `RETAIN_COUNT`           | `None`       | Optional   | `None`                | Optionally, a number to retain, delete older files                            |
+| `PREFIX`                 | `None`       | Optional   | dump                  | Optionally, prefix for dump files                                             |
+| `PGDUMP`                 | `None`       | Optional   | /dump                 | Optionally, define a different location to dump your backups.                 |
+| `LOGFIFO`                | `None`       | Optional   | `${PGDUMP}/cron.fifo` | Location to write cron logs to.                                               |
+| `PG_LOG`                 | `None`       | Optional   | `None`                | Optionally, set any value to view this env inside of the container            |
+| `COMMAND`                | `None`       | Optional   | `dump-cron` | Options: `dump` dumps the database and exit, `dump-cron` creates a cron job and runs    |
+| `RUN_DOUBLE`             | `None`       | Optional   | `true`        | "true" does not enable the PostgreSQL database within this container, "false" does    |
+| `POSTGRES_PASSWORD_FILE` | `None`       | Recomended | `None`                | Location of the password file. Overrides `POSTGRES_PASSWORD` and `PGPASSWORD` |
 
 ## Optional Controls
 
 By default, this container executes as the postgres user. Using a non-root user for your container
-is always a safer route and should be one of your first modifications. The PGPASSWORD field can 
+is always a safer route and should be one of your first modifications. The POSTGRES_PASSWORD field can 
 either be set via environment variable or via docker secrets. Again, for security reasons, it is
-always recommended to use docker secrets for security concerns. An example secrets file can be 
-found below in the docker-compose area. PGPORT is the exposed port in the container, so it is 
-recommended not to change this. 
+always recommended to use docker secrets for security concerns. If using the docker secrets, set the
+POSTGRES_PASSWORD_FILE field, warning this overrides POSTGRES_PASSWORD and PGPASSWORD. An example secrets 
+file can be found below in the docker-compose area. The default for PGHOST is dependant on if RUN_DOUBLE 
+is set; if RUN_DOUBLE is "true" than "db" is the default, if RUN_DOUBLE is "false" than "localhost" is
+the default. PGPORT is the exposed port in the container, so it is recommended not to change this. 
 
-Docker Compose
-==============
+## Docker Compose
 
-Example with docker-compose:
+### Example of running with a single postgreSQL container.
 
 ```yaml
 version: "3.9"
@@ -51,9 +54,10 @@ services:
        - postgres-data:/data:rw
        - postgres-backup:/dump:rw
      environment:
-       - PGDATA=/data   # Where the SQL DB will store itself & backups will dump
-       - RETAIN_COUNT=1 # Keep this number of backups
-       - PGDB=postgres  # The name of the database to dump
+       - PGDATA=/data     # Where the SQL DB will store itself & backups will dump
+       - RETAIN_COUNT=1   # Keep this number of backups
+       - RUN_DOUBLE=false # Run postgresDB as part of this container
+       - POSTGRES_DB=postgres    # The name of the database to dump
        - CRON_SCHEDULE=0 3 * * * # Every day at 3am
        - POSTGRES_PASSWORD_FILE=/run/secrets/db_password # The password file
      restart: unless-stopped
@@ -74,6 +78,33 @@ secrets:
 Secrets file:
 ```text
 PGPASSWORD=SumPassw0rdHere
+```
+
+### Example of running with separate services.
+
+```yaml
+version: "3.9"
+services:
+  database:
+    image: postgres:12.1
+    volumes:
+      - ./persistent/data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=SumPassw0rdHere
+      - POSTGRES_DB=postgres
+    restart: unless-stopped
+
+  postgres-backup:
+    image: martlark/pg_dump:12.1
+    container_name: postgres-backup
+    links:
+      - database:db # Maps as "db"
+    environment:
+      - PGPASSWORD=SumPassw0rdHere
+      - CRON_SCHEDULE=0 3 * * * # Every day at 3am
+      - RETAIN_COUNT=1 # Keep this number of backups
+    volumes:
+      - ./persistent/data:/dump
 ```
 
 Tagged versions

--- a/README.md
+++ b/README.md
@@ -42,30 +42,33 @@ Docker Compose
 Example with docker-compose:
 
 ```yaml
-
-database:
-  image: martlark/pg_dump:12.1
-  container_name: postgres-backup
-  volumes:
-    - postgres-data:/dump:rw
-  environment:
-  environment:
-    - PGDATA=/dump # Where the SQL DB will store itself & backups will dump
-    - CRON_SCHEDULE=0 3 * * * # Every day at 3am
-    - RETAIN_COUNT=1 # Keep this number of backups
-    - PGDB=postgres # The name of the database to dump
-  restart: unless-stopped
-  secrets:
-    - db_password # Contains the PSQL password
+version: "3.9"
+services:
+   database:
+     image: martlark/pg_dump:12.1
+     container_name: postgres-backup
+     volumes:
+       - postgres-data:/data:rw
+       - postgres-backup:/dump:rw
+     environment:
+       - PGDATA=/data   # Where the SQL DB will store itself & backups will dump
+       - RETAIN_COUNT=1 # Keep this number of backups
+       - PGDB=postgres  # The name of the database to dump
+       - CRON_SCHEDULE=0 3 * * * # Every day at 3am
+       - POSTGRES_PASSWORD_FILE=/run/secrets/db_password # The password file
+     restart: unless-stopped
+     secrets:
+       - db_password # Contains the PSQL password
 
 volumes:
    postgres-data:
+      external: true
+   postgres-backup:
       external: true
 
 secrets:
    db_password:
      file: db_password.txt
-
 ```
 
 Secrets file:

--- a/README.md
+++ b/README.md
@@ -6,22 +6,35 @@ here: https://hub.docker.com/repository/docker/martlark/pg_dump
 
 ## Usage
 
-Attach a target postgres container to this container and mount a volume
-to a container's `/dump` folder. Backups will appear in this volume.
-Optionally set up cron job schedule (default is `0 1 * * *` - runs every day at 1:00 am).
+Import a postgreSQL database into this container and mount a volume to the containers `/dump` folder. 
+Backups will appear in this volume. Optionally set up cron job schedule (default is `0 1 * * *` - 
+runs every day at 1:00 am).
 
 ## Environment Variables:
 
-| Variable        | Required? | Default   | Description                                        |
-|-----------------|:----------|:----------|:---------------------------------------------------|
-| `PGUSER`        | Required  | postgres  | The user for accessing the database                |
-| `PGPASSWORD`    | Optional  | `None`    | The password for accessing the database            |
-| `PGDB`          | Optional  | postgres  | The name of the database                           |
-| `PGHOST`        | Optional  | db        | The hostname of the database                       |
-| `PGPORT`        | Optional  | `5432`    | The port for the database                          |
-| `CRON_SCHEDULE` | Required  | 0 1 * * * | The cron schedule at which to run the pg_dump      |
-| `RETAIN_COUNT`  | Optional  | `None`    | Optionally, a number to retain, delete older files |
-| `PREFIX`        | Optional  | dump      | Optionally, prefix for dump files                  |
+| Variable        | Required? | Default   | Description                                                         |
+|-----------------|:----------|:----------|:--------------------------------------------------------------------|
+| `PGUSER`        | Optional  | postgres  | The user for accessing the database                                 |
+| `PGPASSWORD`    | Optional  | `None`    | The password for accessing the database                             |
+| `POSTGRES_DB`   | Optional  | postgres  | The name of the database                                            |
+| `PGHOST`        | Optional  | localhost | The hostname of the database                                        |
+| `PGPORT`        | Optional  | `5432`    | The port for the database                                           |
+| `CRON_SCHEDULE` | Required  | 0 1 * * * | The cron schedule at which to run the pg_dump                       |
+| `RETAIN_COUNT`  | Optional  | `None`    | Optionally, a number to retain, delete older files                  |
+| `PREFIX`        | Optional  | dump      | Optionally, prefix for dump files                                   |
+| `PGDUMP`        | Optional  | /dump     | Optionally, define a different location to dump your backups.       |
+| `LOGFIFO`       | Optional  | `${PGDUMP}/cron.fifo` | Location to write cron logs to.                         |
+| `POSTGRES_PASSWORD_FILE`    | Recomended  | `/run/secrets/db_password` | Location of the password file          |
+| `PG_LOG`        | Optional  | `None`    | Optionally, set any value to view this env inside of the container  |
+
+## Optional Controls
+
+By default, this container executes as the postgres user. Using a non-root user for your container
+is always a safer route and should be one of your first modifications. The PGPASSWORD field can 
+either be set via environment variable or via docker secrets. Again, for security reasons, it is
+always recommended to use docker secrets for security concerns. An example secrets file can be 
+found below in the docker-compose area. PGPORT is the exposed port in the container, so it is 
+recommended not to change this. 
 
 Docker Compose
 ==============
@@ -31,29 +44,33 @@ Example with docker-compose:
 ```yaml
 
 database:
-  image: postgres:12.1
-  volumes:
-    - ./persistent/data:/var/lib/postgresql/data
-  environment:
-    - POSTGRES_PASSWORD=SumPassw0rdHere
-    - POSTGRES_DB=postgres
-  restart: unless-stopped
-
-postgres-backup:
   image: martlark/pg_dump:12.1
   container_name: postgres-backup
-  links:
-    - database:db # Maps as "db"
+  volumes:
+    - postgres-data:/dump:rw
   environment:
-    - PGUSER=postgres
-    - PGPASSWORD=SumPassw0rdHere
+  environment:
+    - PGDATA=/dump # Where the SQL DB will store itself & backups will dump
     - CRON_SCHEDULE=0 3 * * * # Every day at 3am
     - RETAIN_COUNT=1 # Keep this number of backups
-    - PGDB=postgres # The name of the database to dump 
-  #  - PGHOST=db # The hostname of the PostgreSQL database to dump
-  volumes:
-    - ./persistent/data:/dump
+    - PGDB=postgres # The name of the database to dump
+  restart: unless-stopped
+  secrets:
+    - db_password # Contains the PSQL password
 
+volumes:
+   postgres-data:
+      external: true
+
+secrets:
+   db_password:
+     file: db_password.txt
+
+```
+
+Secrets file:
+```text
+PGPASSWORD=SumPassw0rdHere
 ```
 
 Tagged versions

--- a/db_password.txt
+++ b/db_password.txt
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=SumPassw0rdHere

--- a/docker-compose-double.yml
+++ b/docker-compose-double.yml
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
 
   postgres-backup:
-    image: testing-pg-dump #martlark/pg_dump:12.1
+    image: martlark/pg_dump:12.1
     container_name: postgres-backup
     links:
       - database:db # Maps as "db"

--- a/docker-compose-double.yml
+++ b/docker-compose-double.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  database:
+    image: postgres:12.1
+    volumes:
+      - ./persistent/data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=SumPassw0rdHere
+      - POSTGRES_DB=postgres
+    restart: unless-stopped
+
+  postgres-backup:
+    image: testing-pg-dump #martlark/pg_dump:12.1
+    container_name: postgres-backup
+    links:
+      - database:db # Maps as "db"
+    environment:
+      - PGPASSWORD=SumPassw0rdHere
+      - CRON_SCHEDULE=0 3 * * * # Every day at 3am
+      - RETAIN_COUNT=1 # Keep this number of backups
+    volumes:
+      - ./persistent/data:/dump
+      

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+   database:
+     image: martlark/pg_dump:12.1
+     container_name: postgres-backup
+     volumes:
+       - postgres-data:/data:rw
+       - postgres-backup:/dump:rw
+     environment:
+       - PGDATA=/data   # Where the SQL DB will store itself & backups will dump
+       - RETAIN_COUNT=1 # Keep this number of backups
+       - PGDB=postgres  # The name of the database to dump
+       - CRON_SCHEDULE=0 3 * * * # Every day at 3am
+       - POSTGRES_PASSWORD_FILE=/run/secrets/db_password # The password file
+     restart: unless-stopped
+     secrets:
+       - db_password # Contains the PSQL password
+
+volumes:
+   postgres-data:
+      external: true
+   postgres-backup:
+      external: true
+
+secrets:
+   db_password:
+     file: db_password.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
    database:
-     image: martlark/pg_dump:12.1
+     image: testing-pg-dump #martlark/pg_dump:12.1
      container_name: postgres-backup
      volumes:
        - postgres-data:/data:rw
@@ -9,8 +9,9 @@ services:
      environment:
        - PGDATA=/data   # Where the SQL DB will store itself & backups will dump
        - RETAIN_COUNT=1 # Keep this number of backups
-       - PGDB=postgres  # The name of the database to dump
+       - POSTGRES_DB=postgres    # The name of the database to dump
        - CRON_SCHEDULE=0 3 * * * # Every day at 3am
+       - RUN_DOUBLE=false # Run postgresDB as part of this container
        - POSTGRES_PASSWORD_FILE=/run/secrets/db_password # The password file
      restart: unless-stopped
      secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
    database:
-     image: testing-pg-dump #martlark/pg_dump:12.1
+     image: martlark/pg_dump:12.1
      container_name: postgres-backup
      volumes:
        - postgres-data:/data:rw

--- a/dump.sh
+++ b/dump.sh
@@ -4,21 +4,22 @@ set -e
 
 PREFIX=${PREFIX:-dump}
 PGUSER=${PGUSER:-postgres}
-PGDB=${PGDB:-postgres}
-PGHOST=${PGHOST:-db}
+POSTGRES_DB=${POSTGRES_DB:-postgres}
+PGHOST=${PGHOST:-localhost}
 PGPORT=${PGPORT:-5432}
+PGDUMP=${PGDUMP:-'/dump'}
 
 DATE=$(date +%Y%m%d_%H%M%S)
-FILE="/dump/$PREFIX-$PGDB-$DATE.sql"
+FILE="$PGDUMP/$PREFIX-$POSTGRES_DB-$DATE.sql"
 
 echo "Job started: $(date). Dumping to ${FILE}"
 
-pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -f "$FILE" -d "$PGDB"
+pg_dump -h "$PGHOST" -p "$PGPORT" -U "$PGUSER" -f "$FILE" -d "$POSTGRES_DB"
 gzip "$FILE"
 
 if [[ -n "${RETAIN_COUNT}" ]]; then
     file_count=1
-    for file_name in $(ls -t /dump/*.gz); do
+    for file_name in $(ls -t $PGDUMP/*.gz); do
         if [[ ${file_count} > ${RETAIN_COUNT} ]]; then
             echo "Removing older dump file: ${file_name}"
             rm "${file_name}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,25 +2,65 @@
 # entrypoint.sh
 set -e
 
-COMMAND=${1:-dump-cron}
+if [[ -z $COMMAND ]];
+then
+   COMMAND=${1:-dump-cron}
+fi
+
 CRON_SCHEDULE=${CRON_SCHEDULE:-0 1 * * *}
 PREFIX=${PREFIX:-dump}
 PGUSER=${PGUSER:-postgres}
-PGDB=${PGDB:-postgres}
-PGHOST=${PGHOST:-db}
+POSTGRES_DB=${POSTGRES_DB:-postgres}
+PGHOST=${PGHOST:-localhost}
 PGPORT=${PGPORT:-5432}
+PGDUMP=${PGDUMP:-'/dump'}
+POSTGRES_PASSWORD_FILE=${POSTGRES_PASSWORD_FILE:-'/run/secrets/db_password'}
 
+if [[ -n ${PG_LOG} ]];
+then
+   echo "COMMAND: ${COMMAND}"
+   echo "CRON_SCHEDULE: ${CRON_SCHEDULE}"
+   echo "PREFIX: ${PREFIX}"
+   echo "PGUSER: ${PGUSER}"
+   echo "POSTGRES_DB: ${POSTGRES_DB}"
+   echo "PGHOST: ${PGHOST}"
+   echo "PGPORT: ${PGPORT}"
+   echo "PGDUMP: ${PGDUMP}"
+   echo "POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE}"
+fi
+
+if [[ -f /run/secrets/db_password ]];
+then
+   source /run/secrets/db_password
+else
+   echo "ERROR: No password file found!"
+   echo "It is suggested that a docker secrets file is used for security concerns."
+   echo "If not, ensure that POSTGRES_PASSWORD is set."
+fi
 
 if [[ "${COMMAND}" == 'dump' ]]; then
+    /usr/local/bin/docker-entrypoint.sh postgres &
+    SLEEPTIME=5
+    echo "Sleeping ${SLEEPTIME} seconds to allow database to stand up..."
+    sleep ${SLEEPTIME}
     exec /dump.sh
 elif [[ "${COMMAND}" == 'dump-cron' ]]; then
-    LOGFIFO='/var/log/cron.fifo'
+
+    if [[ -z ${LOGFIFO} ]];
+    then
+      LOGFIFO=${PGDUMP}/cron.fifo
+    fi
+
+    if [[ -n ${PG_LOG} ]];
+    then
+        echo "LOGFIFO: ${LOGFIFO}"
+    fi
     if [[ ! -e "${LOGFIFO}" ]]; then
         mkfifo "${LOGFIFO}"
     fi
-    CRON_ENV="PREFIX='$PREFIX'\nPGUSER='${PGUSER}'\nPGDB='${PGDB}'\nPGHOST='${PGHOST}'\nPGPORT='${PGPORT}'"
-    if [[ -n "${PGPASSWORD}" ]]; then
-        CRON_ENV="$CRON_ENV\nPGPASSWORD='${PGPASSWORD}'"
+    CRON_ENV="PREFIX='$PREFIX'\nPGUSER='${PGUSER}'\nPOSTGRES_DB='${POSTGRES_DB}'\nPGHOST='${PGHOST}'\nPGPORT='${PGPORT}'\nPGDUMP='${PGDUMP}'"
+    if [[ -n "${POSTGRES_PASSWORD}" ]]; then
+        CRON_ENV="$CRON_ENV\nPOSTGRES_PASSWORD='${POSTGRES_PASSWORD}'"
     fi
 
     if [[ ! -z "${RETAIN_COUNT}" ]]; then
@@ -30,9 +70,9 @@ elif [[ "${COMMAND}" == 'dump-cron' ]]; then
     echo -e "$CRON_ENV\n$CRON_SCHEDULE /dump.sh > $LOGFIFO 2>&1" | crontab -
     # crontab -l
     cron
-    tail -f "$LOGFIFO"
+    /usr/local/bin/docker-entrypoint.sh postgres
 else
-    echo "Unknown command $COMMAND"
+    echo "Unknown command: $COMMAND"
     echo "Available commands: dump, dump-cron"
     exit 1
 fi


### PR DESCRIPTION
Closes: https://github.com/Martlark/pg_dump/issues/6

Adds:
- Non root user
- Fix deprecated label
- Runs in 1 container instead of 2
- README updates
- docker secrets support
- Sample docker-compose yml
- Env name updates to align more with PSQL
- Log env vars option for debugging